### PR TITLE
Bump Starlette to 1.2.0 and replace httpx with httpx2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "packaging==26.2",
     "pydantic==2.14.0a1",
     "python-json-logger==4.1.0",
-    "starlette==1.1.0",
+    "starlette==1.2.0",
 ]
 
 [dependency-groups]
@@ -40,7 +40,7 @@ lint = [
 tests = [
     { include-group = "coverage" },
     "faker~=40.1",
-    "httpx~=0.28",
+    "httpx2~=2.2.0",
     "pytest~=9.0",
     "pytest-asyncio~=1.3",
     "pytest-github-actions-annotate-failures~=0.3",

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -7,7 +7,7 @@ import unittest.mock
 from typing import TYPE_CHECKING, Any
 
 import fastapi
-import httpx
+import httpx2 as httpx
 import pytest
 from faker import Faker
 from starlette.datastructures import Headers

--- a/uv.lock
+++ b/uv.lock
@@ -275,31 +275,31 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore"
-version = "1.0.9"
+name = "httpcore2"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/7e/8ab39aab1d392845b6512009a9be57d24a5bd4ec7a22d02e513d0645e7a8/httpcore2-2.2.0.tar.gz", hash = "sha256:10e0e142f1ecc1c1cb2a9ebbce82e57f16169f61d163ea336abf36799e89294b", size = 63533, upload-time = "2026-05-17T05:29:55.836Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/39/22/64de17e7956e8c002f7558ed667d924c2a288344aeff4bd8ff5dc5fdb70b/httpcore2-2.2.0-py3-none-any.whl", hash = "sha256:ce859f268bf8d34fa2d7753e09e4dd5194f557e1b3038439b68a89b2999572fa", size = 79288, upload-time = "2026-05-17T05:29:52.56Z" },
 ]
 
 [[package]]
-name = "httpx"
-version = "0.28.1"
+name = "httpx2"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
-    { name = "httpcore" },
+    { name = "httpcore2" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/aa/c3119de1aa7ad870a01aaddbf3bc3445ed9a681c31d45e3838fd8b7bc155/httpx2-2.2.0.tar.gz", hash = "sha256:f3428d59b1752b8f5629826277262fb4d65e3a683f48af8a5b16c4d012e0b801", size = 80477, upload-time = "2026-05-17T05:29:57.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e0/e0a52596c14194e428c20de4903f4abec38c0dfb5364d20f1d4a2b6266ef/httpx2-2.2.0-py3-none-any.whl", hash = "sha256:12347ebd2daeaefd50b529359778fff767082a09c5826752c963e71269722ff0", size = 74083, upload-time = "2026-05-17T05:29:54.543Z" },
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ coverage = [
 dev = [
     { name = "coverage" },
     { name = "faker" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "platformdirs" },
     { name = "pytest" },
@@ -351,7 +351,7 @@ lint = [
 tests = [
     { name = "coverage" },
     { name = "faker" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-github-actions-annotate-failures" },
@@ -360,7 +360,7 @@ tests = [
 typing = [
     { name = "coverage" },
     { name = "faker" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "platformdirs" },
     { name = "pytest" },
@@ -382,7 +382,7 @@ requires-dist = [
     { name = "packaging", specifier = "==26.2" },
     { name = "pydantic", specifier = "==2.14.0a1" },
     { name = "python-json-logger", specifier = "==4.1.0" },
-    { name = "starlette", specifier = "==1.1.0" },
+    { name = "starlette", specifier = "==1.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -395,7 +395,7 @@ coverage = [{ name = "coverage", specifier = "~=7.13" }]
 dev = [
     { name = "coverage", specifier = "~=7.13" },
     { name = "faker", specifier = "~=40.1" },
-    { name = "httpx", specifier = "~=0.28" },
+    { name = "httpx2", specifier = "~=2.2.0" },
     { name = "mypy", specifier = "~=2.1.0" },
     { name = "platformdirs", specifier = "~=4.9" },
     { name = "pytest", specifier = "~=9.0" },
@@ -416,7 +416,7 @@ lint = [
 tests = [
     { name = "coverage", specifier = "~=7.13" },
     { name = "faker", specifier = "~=40.1" },
-    { name = "httpx", specifier = "~=0.28" },
+    { name = "httpx2", specifier = "~=2.2.0" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "pytest-asyncio", specifier = "~=1.3" },
     { name = "pytest-github-actions-annotate-failures", specifier = "~=0.3" },
@@ -425,7 +425,7 @@ tests = [
 typing = [
     { name = "coverage", specifier = "~=7.13" },
     { name = "faker", specifier = "~=40.1" },
-    { name = "httpx", specifier = "~=0.28" },
+    { name = "httpx2", specifier = "~=2.2.0" },
     { name = "mypy", specifier = "~=2.1.0" },
     { name = "platformdirs", specifier = "~=4.9" },
     { name = "pytest", specifier = "~=9.0" },
@@ -831,14 +831,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.1.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Starlette 1.2.0 started recommending `httpx2` and deprecated `httpx` for its native `TestClient`.

I don't use `TestClient`, and instead create a `httpx.AsyncClient` directly in order to support async tests, but let's follow Starlette's lead.

`httpx2` is maintained by the Pydantic team.

- https://github.com/Kludex/starlette/releases/tag/1.2.0
- https://github.com/pydantic/httpx2